### PR TITLE
BUGFIX: Remove Neos.NodeTypes dependency

### DIFF
--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -1,6 +1,6 @@
 'Breadlesscode.ErrorPages:Page':
   superTypes:
-    'Neos.NodeTypes:Page': true
+    'Neos.Neos:Document': true
     'Neos.Neos:Hidable': false
     'Neos.Neos:Timable': false
   ui:


### PR DESCRIPTION
With this change, the package will also work if there is no `Neos.NodeTypes` installed.